### PR TITLE
[BUGFIX] fix category creation issue

### DIFF
--- a/flaskbb/management/forms.py
+++ b/flaskbb/management/forms.py
@@ -398,5 +398,8 @@ class CategoryForm(Form):
     submit = SubmitField(_("Save"))
 
     def save(self):
-        category = Category(**self.data)
+        data = self.data
+        # remove the button
+        data.pop('submit', None)
+        category = Category(**data)
         return category.save()


### PR DESCRIPTION
Passing **kwargs to category save method cases it to fail on mysql backend, as SQA strictly checks if all passed kwargs match model fields. Since value of submit button is also passed from the form and exception is raised.

Fixed by excluding 'submit' button from passed data.