### PR TITLE
[BUGFIX] fix migration for mysql 

### DIFF
--- a/migrations/versions/8ad96e49dc6_init.py
+++ b/migrations/versions/8ad96e49dc6_init.py
@@ -51,7 +51,7 @@ def upgrade():
     op.create_table('settings',
     sa.Column('key', sa.String(length=255), nullable=False),
     sa.Column('value', sa.PickleType(), nullable=False),
-    sa.Column('settingsgroup', sa.String(), nullable=False),
+    sa.Column('settingsgroup', sa.String(length=255), nullable=False),
     sa.Column('name', sa.String(length=200), nullable=False),
     sa.Column('description', sa.Text(), nullable=False),
     sa.Column('value_type', sa.String(length=20), nullable=False),


### PR DESCRIPTION
Varchar fields require length to be specified. 'settingsgroup' was missing this attribute, and migration failed on mysql backend.

Fixed by adding length attribute