### PR TITLE
[BUGFIX] fix for category sorting

### DIFF
--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -924,14 +924,14 @@ class Category(db.Model):
                                   ForumsRead.user_id == user.id)).\
                 add_entity(Forum).\
                 add_entity(ForumsRead).\
-                order_by(Category.id, Category.position, Forum.position).\
+                order_by(Category.position, Category.id,  Forum.position).\
                 all()
         else:
             # Get all the forums
             forums = cls.query.\
                 join(Forum, cls.id == Forum.category_id).\
                 add_entity(Forum).\
-                order_by(Category.id, Category.position, Forum.position).\
+                order_by(Category.position, Category.id, Forum.position).\
                 all()
 
         return get_categories_and_forums(forums, user)


### PR DESCRIPTION
Category sorting on forum index view has wring sorting priority: instead of sorting by position first, it takes id first.

Fixed by swapping id and position fields in order_by