### PR TITLE
Add support for running tests from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.3"
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt"
+  - "pip install -r test_requirements.txt"
   - "pip install coveralls"
 # command to run tests
 script:

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,4 +10,5 @@ contributors:
 # Contributors
 
 * CasperVg
+* Alec Reiter <https://github.com/justanr>
 * Feel free to join! :)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,11 +20,7 @@ Jinja2==2.7.3
 Mako==1.0.1
 MarkupSafe==0.23
 mistune==0.6
-py==1.4.29
 Pygments==2.0.2
-pytest==2.7.2
-pytest-cov==1.8.1
-pytest-random==0.2
 pytz==2015.4
 redis==2.10.3
 requests==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,27 @@ Resources
 
 """
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+import sys
+
+
+class PyTestCommand(TestCommand):
+    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
+
+    def initialize_options(self):
+        super(PyTestCommand, self).initialize_options()
+        self.pytest_args = []
+
+    def finalize_options(self):
+        super(PyTestCommand, self).finalize_options()
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 setup(
     name='FlaskBB',
@@ -69,16 +90,19 @@ setup(
         'coverage',
         'itsdangerous',
         'mistune',
-        'py',
-        'pytest',
-        'pytest-cov',
-        'pytest-random',
         'pytz',
         'redis',
         'requests',
         'simplejson',
         'speaklater',
         'sqlalchemy-utils'
+    ],
+    test_suite='tests',
+    tests_require=[
+        'py',
+        'pytest',
+        'pytest-cov',
+        'pytest-random'
     ],
     dependency_links=[
         'https://github.com/jshipley/Flask-WhooshAlchemy/archive/master.zip#egg=Flask-WhooshAlchemy',
@@ -94,5 +118,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+    ],
+    cmdclass={'test': PyTestCommand}
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+py==1.4.29
+pytest==2.7.2
+pytest-cov==1.8.1
+pytest-random==0.2


### PR DESCRIPTION
Now possible to run tests with python setup.py test. Additional arguments can be passed to py.test with the '--pytest-args="opts"' flag. This commit also separates test requirements (py/pytest/pytest exts) from standard install requirements.