### PR TITLE
Change whoosh_index to use MajorMinor for storage directory

### DIFF
--- a/flaskbb/configs/default.py
+++ b/flaskbb/configs/default.py
@@ -10,6 +10,9 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
+import sys
+
+_VERSION_STR = '{0.major}{0.minor}'.format(sys.version_info)
 
 
 class DefaultConfig(object):
@@ -50,7 +53,7 @@ class DefaultConfig(object):
     WTF_CSRF_SECRET_KEY = "reallyhardtoguess"
 
     # Searching
-    WHOOSH_BASE = os.path.join(_basedir, "whoosh_index")
+    WHOOSH_BASE = os.path.join(_basedir, "whoosh_index", _VERSION_STR)
 
     # Auth
     LOGIN_VIEW = "auth.login"


### PR DESCRIPTION
Python 3 and 2 use separate Pickle protocols. I first stumbled across this some time ago and noted it in #91. This patch changes the storage location to use the major and minor version in the storage directory. This benefits testing across multiple version than actual run time. Though, I'm sure with some prodding there could be some migration from a Python 2 install to a Python 3 install.