### PR TITLE
Add sudo: false to use travis' container architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
   - "3.3"


### PR DESCRIPTION
Adding sudo: false allows us to take advantage of Travis's container architecture. I've seen test speed gains between thirty seconds and a minute on my fork.