### PR TITLE
Better install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
-.PHONY: clean
+.PHONY: clean install help test run dependencies
 
 help:
-	    @echo "  clean      remove unwanted stuff"
-	    @echo "  install    install testend"
-	    @echo "  tests       run the testsuite"
-	    @echo "  run        run the development server"
+	@echo "  clean      remove unwanted stuff"
+	@echo "  install    install flaskbb and setup"
+	@echo "  tests      run the testsuite"
+	@echo "  run        run the development server"
+
+dependencies:requirements.txt
+	pip install -r requirements.txt
 
 clean:
-	    find . -name '*.pyc' -exec rm -f {} +
-	    find . -name '*.pyo' -exec rm -f {} +
-	    find . -name '*~' -exec rm -f {} +
-	    find . -name '__pycache__' -exec rm -rf {} +
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -rf {} +
 
 test:
-	    py.test --cov=flaskbb --cov-report=term-missing tests
+	py.test --cov=flaskbb --cov-report=term-missing tests
 
 run:
-	    python manage.py runserver
+	python manage.py runserver -dr
 
-install:
-	    python manage.py install
+install:dependencies
+	clear
+	python manage.py install

--- a/README.md
+++ b/README.md
@@ -34,15 +34,12 @@ For a complete installation guide please visit the installation documentation
 [here](https://flaskbb.readthedocs.org/en/latest/installation.html).
 
 * Create a virtualenv
-* Install the dependencies
-    * `pip install -r requirements.txt`
 * Configuration (_adjust them accordingly to your needs_)
     * For development copy `flaskbb/configs/development.py.example` to `flaskbb/configs/development.py`
-* Create the database & populate it
-    * `python manage.py initdb`
-    * `python manage.py populate`
+* Install dependencies and FlaskBB
+    * `make install`
 * Run the development server
-    * `python manage.py runserver`
+    * `make runserver`
 * Visit [localhost:8080](http://localhost:8080)
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,12 @@ Required Dependencies
 Now you can install the required dependencies.
 ::
 
-     $ pip install -r requirements.txt
+    $ pip install -r requirements.txt
+
+Alternatively, you can use the `make` command to install the dependencies.
+::
+
+    $ make dependencies
 
 
 Optional Dependencies
@@ -150,29 +155,19 @@ Both methods are included in the example configs.
 Installation
 ------------
 
-
-Development
-~~~~~~~~~~~
-
-For development you can create the database with the command below. This will
-additional to the database also create a few users with some example content.
+For a guided install, run
 ::
 
-    python manage.py createall
+    $ make install
 
-To test if everything has worked, run the development server with
-``python manage.py runserver``.
+or:
 
-Production
-~~~~~~~~~~
-
-Now, you can start the installation process with
-::
-
-    python manage.py initflaskbb
+    python manage.py install
 
 During the installation process you are asked about your username,
-your email address and the password for your administrator user.
+your email address and the password for your administrator user. Using the 
+`make install` command is recommended as it checks that the dependencies are also
+installed.
 
 
 Upgrading


### PR DESCRIPTION
Updates install instructions, putting a preference towards using the `Makefile`. Closes #147 but does not fix it. For the time being use `make install` for the dependencies + guided setup, or just `make dependencies` or `pip install -r requirements.txt` for just the dependencies (this is not noted in the install docs as there's still the required database setup needed).