### PR TITLE
fix bug in default settings - Bootstrap themes have bits missing

### DIFF
--- a/flaskbb/fixtures/settings.py
+++ b/flaskbb/fixtures/settings.py
@@ -141,7 +141,7 @@ fixture = (
         "description": "Change the theme and language for your forum.",
         "settings": (
             ('default_theme', {
-                'value':        "bootstrap3",
+                'value':        "aurora",
                 'value_type':   "select",
                 'extra':        {'choices': available_themes},
                 'name':         "Default Theme",


### PR DESCRIPTION
This fixes issue #156 in that it makes the default when you run "make install" to be Aurora rather than the buggy Bootstrap theme.