### PR TITLE
Move form.process()

### DIFF
--- a/flaskbb/auth/views.py
+++ b/flaskbb/auth/views.py
@@ -93,7 +93,6 @@ def register():
 
     form.language.choices = available_languages()
     form.language.default = flaskbb_config['DEFAULT_LANGUAGE']
-    form.process()  # needed because a default is overriden
 
     if form.validate_on_submit():
         user = form.save()
@@ -101,6 +100,8 @@ def register():
 
         flash(_("Thanks for registering."), "success")
         return redirect(url_for("user.profile", username=current_user.username))
+
+    form.process()  # needed because a default is overriden
     return render_template("auth/register.html", form=form)
 
 

--- a/flaskbb/auth/views.py
+++ b/flaskbb/auth/views.py
@@ -93,6 +93,7 @@ def register():
 
     form.language.choices = available_languages()
     form.language.default = flaskbb_config['DEFAULT_LANGUAGE']
+    form.process(request.form)  # needed because a default is overriden
 
     if form.validate_on_submit():
         user = form.save()
@@ -101,7 +102,6 @@ def register():
         flash(_("Thanks for registering."), "success")
         return redirect(url_for("user.profile", username=current_user.username))
 
-    form.process()  # needed because a default is overriden
     return render_template("auth/register.html", form=form)
 
 

--- a/flaskbb/templates/layout.html
+++ b/flaskbb/templates/layout.html
@@ -45,8 +45,8 @@
                 {% block header %}
                 <div class="flaskbb-header">
                     <div class="flaskbb-meta">
-                        <div class="flaskbb-title">FlaskBB</div>
-                        <div class="flaskbb-subtitle">A lightweight forum software in Flask.</div>
+                        <div class="flaskbb-title">{{ flaskbb_config["PROJECT_TITLE"] }}</div>
+                        <div class="flaskbb-subtitle">{{ flaskbb_config["PROJECT_SUBTITLE"] }}</div>
                     </div>
                 </div>
                 {% endblock %}


### PR DESCRIPTION
form.process() seems to wipe out the form data before validate_on_submit() gets a chance to see it.

Moving form.process() to just before the form is rendered if we're not validating prevents this, but may also wipe out data if we enter something invalid into the form (mismatching passwords, for example)

This appears to fix #159 at least for me