### PR TITLE
Improvement 172 adds recaptcha for login and forgot_password forms

### DIFF
--- a/flaskbb/auth/forms.py
+++ b/flaskbb/auth/forms.py
@@ -82,6 +82,10 @@ class RegisterRecaptchaForm(RegisterForm):
     recaptcha = RecaptchaField(_("Captcha"))
 
 
+class LoginRecaptchaForm(LoginForm):
+    recaptcha = RecaptchaField(_("Captcha"))
+
+
 class ReauthForm(Form):
     password = PasswordField(_('Password'), validators=[
         DataRequired(message=_("A Password is required."))])
@@ -95,6 +99,10 @@ class ForgotPasswordForm(Form):
         Email()])
 
     submit = SubmitField(_("Request Password"))
+
+
+class ForgotPasswordRecaptchaForm(ForgotPasswordForm):
+    recaptcha = RecaptchaField(_("Captcha"))
 
 
 class ResetPasswordForm(Form):

--- a/flaskbb/auth/views.py
+++ b/flaskbb/auth/views.py
@@ -34,7 +34,11 @@ def login():
     if current_user is not None and current_user.is_authenticated():
         return redirect(url_for("user.profile"))
 
-    form = LoginForm(request.form)
+    if current_app.config["RECAPTCHA_ENABLED"]:
+        from flaskbb.auth.forms import LoginRecaptchaForm
+        form = LoginRecaptchaForm(request.form)
+    else:
+        form = LoginForm(request.form)
     if form.validate_on_submit():
         user, authenticated = User.authenticate(form.login.data,
                                                 form.password.data)
@@ -114,7 +118,12 @@ def forgot_password():
     if not current_user.is_anonymous():
         return redirect(url_for("forum.index"))
 
-    form = ForgotPasswordForm()
+    if current_app.config["RECAPTCHA_ENABLED"]:
+        from flaskbb.auth.forms import ForgotPasswordRecaptchaForm
+        form = ForgotPasswordRecaptchaForm(request.form)
+    else:
+        form = ForgotPasswordForm()
+
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
 

--- a/flaskbb/templates/auth/forgot_password.html
+++ b/flaskbb/templates/auth/forgot_password.html
@@ -13,6 +13,9 @@
         <form class="form-horizontal" role="form" method="POST">
             {{ form.hidden_tag() }}
             {{ horizontal_field(form.email) }}
+             {% if config["RECAPTCHA_ENABLED"] %}
+                {{ horizontal_field(form.recaptcha) }}
+            {% endif %}
             {{ horizontal_field(form.submit)}}
         </form>
     </div>

--- a/flaskbb/templates/auth/login.html
+++ b/flaskbb/templates/auth/login.html
@@ -14,6 +14,9 @@
             {{ form.hidden_tag() }}
             {{ horizontal_field(form.login)}}
             {{ horizontal_field(form.password)}}
+            {% if config["RECAPTCHA_ENABLED"] %}
+                {{ horizontal_field(form.recaptcha) }}
+            {% endif %}
             {{ horizontal_field(form.remember_me) }}
             {{ horizontal_field(form.submit) }}
 


### PR DESCRIPTION
issue #172 
Adds Recaptcha to prevent brute force attacks. Is only enabled when RECAPTCHA_ENABLED is True
 - [x] Login form recaptcha
 - [x] Forgot password form.


p.s. first pull request ever so please correct me if I am doing something obviously wrong much appreciate it.