### PR TITLE
Fixed the apt-get call for installing uWSGI

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -234,7 +234,7 @@ This can be done with:
 
 ::
 
-    $ sudo apt-get install uwsgi uwsgi-plugins-python
+    $ sudo apt-get install uwsgi uwsgi-plugin-python
 
 For the configuration, you need to create a file in the
 ``/etc/uwsgi/apps-available`` directory. In this example, I will call the


### PR DESCRIPTION
Changed `uwsgi-plugins-python` to `uwsgi-plugin-python` as the former is incorrect and fails.