### PR TITLE
Turn key docker solution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.tgz
+*.tar.gz
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+whoosh_index
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# Project Related #
+###################
+.project
+.geanyprj
+.pydevproject
+.idea
+__pycache__
+*.nja
+*.pyc
+*.db
+.venv
+*.sublime-workspace
+*.sublime-project
+*.egg-info
+*.iml
+.tox
+*.rdb
+.cache
+*.mo
+.coverage
+flaskbb/static/emoji/*
+.sass-cache
+bower_components
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.5
+
+
+RUN apt-get update && apt-get install -qq -y build-essential --fix-missing --no-install-recommends
+
+ENV INSTALL_PATH /flaskbb
+ENV TERM xterm
+
+RUN mkdir -p $INSTALL_PATH
+WORKDIR  $INSTALL_PATH
+
+COPY . .
+
+RUN pip install -r requirements.txt
+
+RUN make uinstall
+
+VOLUME ["$INSTALL_PATH/build/public"]
+
+CMD python manage.py runserver -dr -p 8000  -h 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: clean install help test run dependencies
+.PHONY: clean install help test run dependencies uinstall
 
 help:
 	@echo "  clean      remove unwanted stuff"
 	@echo "  install    install flaskbb and setup"
-	@echo "  test      run the testsuite"
+	@echo "  test       run the testsuite"
 	@echo "  run        run the development server"
+	@echo "  uinstall   unattended install"
 
 dependencies:requirements.txt
 	pip install -r requirements.txt
@@ -24,3 +25,6 @@ run:
 install:dependencies
 	clear
 	python manage.py install
+
+uinstall:
+	python manage.py unattended_install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+flaskbb:
+    build: .
+    volumes:
+        - .:/flaskbb
+    ports:
+        - "8000:8000"

--- a/manage.py
+++ b/manage.py
@@ -159,6 +159,21 @@ def install(username=None, password=None, email=None):
 
 
 @manager.command
+def unattended_install():
+    print("Creating/upgrading database...")
+    initdb()
+    print("Creating default groups, settings, user and forum...")
+    create_default_groups()
+    create_default_settings()
+    create_admin('admin', 'admin', 'admin@admin')
+    create_welcome_forum()
+    print("Compiling translations...")
+    compile_translations()
+    print("Downloading emojis....")
+    download_emoji()
+
+
+@manager.command
 def insertmassdata():
     """Warning: This can take a long time!.
     Creates 100 topics and each topic contains 100 posts.


### PR DESCRIPTION
Sharing this, despite being in progress. I'm trying to create a turn key Docker install for users who would like to host a FlaskBB Instance but can't install all the needed server packages (Database, Redis, etc). It'll also ensure there's repeatable installations that can be automated.

Right now, all it does is spin up a basic debugged, reloaded FlaskBB instance. But I'm hoping to have a mostly fleshed out version soon.
- Make sure docker and docker-compose are installed (instructions on docker.com for your ~~poison~~ OS of choice
- `docker-compose build`
- `docker-compose up` -> localhost:8000

But if you actually want to use the forum, you should be an `make install` before hand (to populate the sqlite file). Working on this currently. I'm not sure if any changes made with the running container will be persisted out.
## Notes

This currently adds `python manage.py unattended_install` and `make uinstall` -- these are currently only for use with the docker process. They work, but they'll probably screw up existing data if you run them.
## Todos
- [ ] Persisted RDBMS (Postgres is what I'm leaning towards, but free to consider MariaDB or any others with a prebuilt docker image) 
- [ ] Redis
- [ ] uWSGI + Nginx
- [ ] Configurable install (envars? Not sure...)
- [ ] entry points -- used with docker-compose run to preform actions.
- [ ] better build output -- looks like it hangs but it's really downloading emojis.
- [ ] docker populates some folders in the directory where the container is built. :(
