### PR TITLE
Sorting member list

### DIFF
--- a/flaskbb/templates/forum/memberlist.html
+++ b/flaskbb/templates/forum/memberlist.html
@@ -4,6 +4,9 @@
 {% block content %}
 {% from theme('macros.html') import render_pagination, input_group_field %}
 
+{% set order_by = 'desc' if request.args.get('order_by') == 'asc' else 'asc' %}
+{% set sort_by = request.args.get('sort_by') %}
+
 <div class="page-view">
     <ol class="breadcrumb flaskbb-breadcrumb">
         <li><a href="{{ url_for('forum.index') }}">{% trans %}Forum{% endtrans %}</a></li>
@@ -13,7 +16,7 @@
     <div class="row controls-row">
         <div class="col-md-8 col-sm-8 col-xs-8 controls-col">
             <div class="pull-left">
-                {{ render_pagination(users, url_for('forum.memberlist')) }}
+                {{ render_pagination(users, url_for('forum.memberlist'), sort_by=sort_by, asc=(order_by == 'desc')) }}
             </div>
         </div>
         <div class="col-md-4 col-sm-4 col-xs-4 controls-col">
@@ -37,7 +40,6 @@
         </div>
         <div class="panel-body page-body">
             <div class="page-meta">
-                {% set order_by = 'desc' if request.args.get('order_by') == 'asc' else 'asc' %}
                 <div class="col-md-1 col-sm-1 col-xs-1 meta-item">#</div>
                 <div class="col-md-3 col-sm-3 col-xs-5 meta-item">
                     <a href="{{ url_for('forum.memberlist') }}?sort_by=username&order_by={{ order_by }}">{% trans %}Username{% endtrans %}</a>

--- a/flaskbb/templates/macros.html
+++ b/flaskbb/templates/macros.html
@@ -320,13 +320,15 @@
 </li>
 {% endmacro %}
 
-{% macro render_pagination(page_obj, url, ul_class='') %}
+{% macro render_pagination(page_obj, url, ul_class='', sort_by=None, asc=True) %}
 <ul class='{%- if ul_class -%}{{ ul_class }}{%- else -%}pagination{%- endif -%}'>
+    {% set ordering = 'asc' if asc == True else 'desc' %}
+    {% set sorting = '&sort_by='+(sort_by|urlencode)+'&order_by='+ordering if sort_by is string else '' %}
     <li class="disabled"><a href="#"><span class="pages-label">{% trans %}Pages{% endtrans %}:</span></a></li>
     {%- for page in page_obj.iter_pages() %}
         {% if page %}
             {% if page != page_obj.page %}
-                <li><a href="{{ url }}?page={{ page }}">{{ page }}</a></li>
+                <li><a href="{{ url }}?page={{ page }}{{ sorting }}">{{ page }}</a></li>
             {% else %}
                 <li class="active"><a href="#">{{ page }}</a></li>
             {% endif %}
@@ -335,11 +337,10 @@
         <li class="active"><a href="#">1</a></li>
     {%- endfor %}
     {% if page_obj.has_next %}
-        <li><a href="{{ url }}?page={{ page_obj.next_num }}">&raquo;</a></li>
+        <li><a href="{{ url }}?page={{ page_obj.next_num }}{{ sorting }}">&raquo;</a></li>
     {% endif %}
 </ul>
 {% endmacro %}
-
 
 {% macro render_topic_pagination(page_obj, url) %}
 <ul class="pagination pagelink pull-left">


### PR DESCRIPTION
As described in the forum (https://forums.flaskbb.org/post/162) the sorting of the member list gets lost if the users wants to see any other page of the member list except for the first page.
This PR changes the memberlist template to extract the sorting and ordering and passes it to the render_pagination macro, where these arguments are added as optional arguments. If passed, sort_by and order_by arguments get injected to the page links.
For safety reasons, sort_by is URL-escaped while order_by is passed as bool.