### PR TITLE
Rename topics is not possible

### DIFF
--- a/flaskbb/forum/views.py
+++ b/flaskbb/forum/views.py
@@ -438,23 +438,39 @@ def edit_post(post_id):
               "danger")
         return redirect(post.topic.url)
 
-    form = ReplyForm()
+    if post.first_post:
+        form = NewTopicForm()
+    else:
+        form = ReplyForm()
+
     if form.validate_on_submit():
         if "preview" in request.form:
             return render_template(
                 "forum/new_post.html", topic=post.topic,
-                form=form, preview=form.content.data
+                form=form, preview=form.content.data, edit_mode=True
             )
         else:
             form.populate_obj(post)
             post.date_modified = time_utcnow()
             post.modified_by = current_user.username
             post.save()
+
+            if post.first_post:
+                post.topic.title = form.title.data
+                post.topic.save()
             return redirect(post.topic.url)
     else:
+        if post.first_post:
+            form.title.data = post.topic.title
+
         form.content.data = post.content
 
-    return render_template("forum/new_post.html", topic=post.topic, form=form)
+    return render_template(
+        "forum/new_post.html",
+        topic=post.topic,
+        form=form,
+        edit_mode=True
+    )
 
 
 @forum.route("/post/<int:post_id>/delete", methods=["POST"])

--- a/flaskbb/templates/forum/new_post.html
+++ b/flaskbb/templates/forum/new_post.html
@@ -4,25 +4,39 @@
 {% extends theme("layout.html") %}
 
 {% block content %}
-{% from theme("macros.html") import render_quickreply, render_submit_field %}
+{% from theme("macros.html") import render_quickreply, render_submit_field, render_field %}
 
 <div class="page-view">
     <ol class="breadcrumb flaskbb-breadcrumb">
         <li><a href="{{ url_for('forum.index') }}">{% trans %}Forum{% endtrans %}</a></li>
         <li><a href="{{ topic.forum.url }}">{{ topic.forum.title }}</a></li>
         <li><a href="{{ topic.url }}">{{ topic.title }}</a></li>
-        <li class="active">{% trans %}New Post{% endtrans %}</li>
+        <li class="active">
+            {% if edit_mode %}
+                {% trans %}Edit Post{% endtrans %}
+            {% else %}
+                {% trans %}New Post{% endtrans %}
+            {% endif %}
+        </li>
     </ol>
 
     <form class="form-horizontal" role="form" method="post">
         {{ form.hidden_tag() }}
         <div class="panel page-panel">
             <div class="panel-heading page-head">
-                {% trans %}New Post{% endtrans %}
+                {% if edit_mode %}
+                    {% trans %}Edit Post{% endtrans %}
+                {% else %}
+                    {% trans %}New Post{% endtrans %}
+                {% endif %}
             </div>
 
             <div class="panel-body page-body">
                 <div class="col-md-12 col-sm-12 col-xs-12">
+
+                    {% if form.title %}
+                        {{ render_field(form.title, div_class="col-md-12 col-sm-12 col-xs-12") }}
+                    {% endif %}
 
                     <div class="form-group">
                         <div class="col-md-12 col-sm-12 col-xs-12">


### PR DESCRIPTION
Closes #244: Rename topics is not possible
Add the condition to choose proper form class in forum/views.py
Render title field in template if it is necessary.
Very small improvement of template to show proper title in breadcrumbs and form header.

Also the slugs are changing properly, didn't have to do anything with them, the redirect working as it should.

P.S. I've noticed that a lot of editing actions are using create-templates. There are wrong messages in this cases. For example, in edit post the submit button says "Reply". I'll create an issue about improvement, if you don't mind

/cc @kwijybo 