### PR TITLE
Ignore plugins in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ flaskbb/static/emoji/*
 bower_components
 node_modules
 .directory
+
+# Ignore plugins
+flaskbb/plugins/*
+!flaskbb/plugins/__init__.py
+!flaskbb/plugins/portal/


### PR DESCRIPTION
Usally the plugins of a user should not be part of the base repository. The developer of the plugin should rather create a own git repository in the plugin folder itself as the are thought to be self contained I think.
So I added a wildcard to ignore the content of the plugins directory and explicitly added the init script and the portal folder.