### PR TITLE
Redirect user to first unread post of a topic

### DIFF
--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import aliased
 
 from flaskbb.extensions import db
 from flaskbb.utils.helpers import (slugify, get_categories_and_forums,
-                                   get_forums, time_utcnow)
+                                   get_forums, time_utcnow, topic_is_unread)
 from flaskbb.utils.database import CRUDMixin, UTCDateTime
 from flaskbb.utils.settings import flaskbb_config
 
@@ -321,6 +321,32 @@ class Topic(db.Model, CRUDMixin):
     def url(self):
         """Returns the slugified url for the topic."""
         return url_for("forum.view_topic", topic_id=self.id, slug=self.slug)
+
+    def first_unread(self, topicsread, user, forumsread=None):
+        """Returns the url to the first unread post if any else to the topic
+        itself.
+
+        :param topicsread: The topicsread object for the topic
+
+        :param user: The user who should be checked if he has read the last post
+                    in the topic
+
+        :param forumsread: The forumsread object in which the topic is. If you
+                        also want to check if the user has marked the forum as
+                        read, than you will also need to pass an forumsread
+                        object.
+        """
+
+        # If the topic is unread try to get the first unread post
+        if topic_is_unread(self, topicsread, user, forumsread):
+            # 
+            post = Post.query.filter(Post.topic_id == self.id).\
+                filter(Post.date_created > topicsread.last_read).\
+                order_by(Post.id.asc()).first()
+            if post is not None:
+                return post.url
+        
+        return self.url
 
     # Methods
     def __init__(self, title=None, user=None):

--- a/flaskbb/templates/forum/forum.html
+++ b/flaskbb/templates/forum/forum.html
@@ -76,7 +76,7 @@
                         </div>
                         <div class="col-md-11 col-sm-10 col-xs-10">
                             <div class="topic-name">
-                                <a href="{{ topic.url }}">{{ topic.title }}</a>
+                                <a href="{{ topic.first_unread(topicread, current_user, forumsread) }}">{{ topic.title }}</a>
                                 <!-- Topic Pagination -->
                                 <span class="topic-pages">{{ topic_pages(topic, flaskbb_config["POSTS_PER_PAGE"]) }}</span>
                             </div>


### PR DESCRIPTION
If there are new posts to a topic the users usually wants to continue
reading at the first post (s)he has not read.
Therefore the users should be redirected to the first unread post when
clicking the topic in the forum view. If there is no unread post, the
user will be send to the topic itself, i.e. the first post