### PR TITLE
Force users to accept TOS.

### DIFF
--- a/flaskbb/auth/forms.py
+++ b/flaskbb/auth/forms.py
@@ -58,7 +58,8 @@ class RegisterForm(FlaskForm):
 
     language = SelectField(_('Language'))
 
-    accept_tos = BooleanField(_("I accept the Terms of Service"), default=True)
+    accept_tos = BooleanField(_("I accept the Terms of Service"), validators=[
+        DataRequired(message=_("Please accept the TOS."))], default=True)
 
     submit = SubmitField(_("Register"))
 


### PR DESCRIPTION
Users are currently able to register without accepting the terms of service. The TOS is currently auto selected but a user could deselect the box and still register. This prevents a user from registering without accepting the TOS.