### PR TITLE
Fix a bug about show a forum list

### DIFF
--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -340,9 +340,10 @@ class Topic(db.Model, CRUDMixin):
         # If the topic is unread try to get the first unread post
         if topic_is_unread(self, topicsread, user, forumsread):
             # 
-            post = Post.query.filter(Post.topic_id == self.id).\
-                filter(Post.date_created > topicsread.last_read).\
-                order_by(Post.id.asc()).first()
+            query = Post.query.filter(Post.topic_id == self.id)
+            if topicsread is not None:
+                query = query.filter(Post.date_created > topicsread.last_read)
+            post = query.order_by(Post.id.asc()).first()
             if post is not None:
                 return post.url
         


### PR DESCRIPTION
When a user visit a forum that he never visit,
he will get a 500 error because a AttributeError:

File "./flaskbb/forum/models.py", line 344, in first_unread
  filter(Post.date_created > topicsread.last_read).\
      AttributeError: 'NoneType' object has no attribute 'last_read'