### PR TITLE
static post links

### DIFF
--- a/flaskbb/templates/forum/topic.html
+++ b/flaskbb/templates/forum/topic.html
@@ -65,7 +65,7 @@
                     <div class="post-meta clearfix">
                         <div class="pull-left">
                             <!-- Creation date / Date modified -->
-                            <a href="{{ generate_post_url(topic, post, posts.page) }}">
+                            <a href="{{ post.url }}">
                                 {{ post.date_created|format_date('%d %B %Y - %H:%M') }}
                             </a>
                             {% if post.user_id and post.date_modified %}

--- a/flaskbb/templates/forum/topic_horizontal.html
+++ b/flaskbb/templates/forum/topic_horizontal.html
@@ -66,7 +66,7 @@
                     <div class="post-meta clearfix">
                         <div class="pull-left">
                             <!-- Creation date / Date modified -->
-                            <a href="{{ generate_post_url(topic, post, posts.page) }}">
+                            <a href="{{ post.url }}">
                                 {{ post.date_created|format_date('%d %B %Y - %H:%M') }}
                             </a>
                             {% if post.user_id and post.date_modified %}


### PR DESCRIPTION
changed template for topics to generate use static links to post, that
still work if posts per page changes or topics are renamed/merged or whatever