### PR TITLE
Whooshee breaks manage.py install

### DIFF
--- a/flaskbb/configs/default.py
+++ b/flaskbb/configs/default.py
@@ -172,6 +172,7 @@ class DefaultConfig(object):
     # Celery
     CELERY_BROKER_URL = 'redis://localhost:6379'
     CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+    if not REDIS_ENABLED: CELERY_ALWAYS_EAGER=True
 
     # FlaskBB Settings
     # ------------------------------ #

--- a/flaskbb/utils/populate.py
+++ b/flaskbb/utils/populate.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by the FlaskBB Team.
     :license: BSD, see LICENSE for more details.
 """
+from __future__ import unicode_literals
 from flaskbb.management.models import Setting, SettingsGroup
 from flaskbb.user.models import User, Group
 from flaskbb.forum.models import Post, Topic, Forum, Category

--- a/flaskbb/utils/search.py
+++ b/flaskbb/utils/search.py
@@ -65,7 +65,7 @@ class TopicWhoosheer(AbstractWhoosheer):
             topic_id=topic.id,
             title=topic.title,
             username=topic.username,
-            content=topic.first_post.content
+            content=getattr(topic.first_post,'content',None)
         )
 
     @classmethod
@@ -74,7 +74,7 @@ class TopicWhoosheer(AbstractWhoosheer):
             topic_id=topic.id,
             title=topic.title,
             username=topic.username,
-            content=topic.first_post.content
+            content=getattr(topic.first_post,'content',None)
         )
 
     @classmethod

--- a/manage.py
+++ b/manage.py
@@ -114,9 +114,9 @@ def create_admin(username=None, password=None, email=None):
     """Creates the admin user."""
 
     if not (username and password and email):
-        username = prompt("Username")
-        email = prompt("A valid email address")
-        password = prompt_pass("Password")
+        username = unicode(prompt("Username"))
+        email = unicode(prompt("A valid email address"))
+        password = unicode(prompt_pass("Password"))
 
     create_admin_user(username=username, password=password, email=email)
 


### PR DESCRIPTION
On my setup (fresh download of master branch on python 2.7 and windows) - the manage.py install fails 
- the whoosheer is fed a str rather than a Unicode during the interactive setup and again during the setting up of the welcome forum 
- the topic is saved before the first post is attached- so the whoosheer throws an AttributeError

the fix here works for me
Also, all email and other Celery related activity is dependent on Redis being available even if REDIS_AVAILABLE=False so this fix also disables Celery if Redis is not active