### PR TITLE
fix manage.py for Python 3

### DIFF
--- a/flaskbb/_compat.py
+++ b/flaskbb/_compat.py
@@ -36,6 +36,6 @@ def to_bytes(text):
 
 def to_unicode(input_bytes, encoding='utf-8'):
     """Decodes input_bytes to text if needed."""
-    if not isinstance(input_bytes, string_types):
+    if not isinstance(input_bytes, text_type):
         input_bytes = input_bytes.decode(encoding)
     return input_bytes

--- a/manage.py
+++ b/manage.py
@@ -32,6 +32,7 @@ from flask_script import (Manager, Shell, Server, prompt, prompt_pass,
 from flask_migrate import MigrateCommand, upgrade
 
 from flaskbb import create_app
+from flaskbb._compat import to_unicode
 from flaskbb.extensions import db, plugin_manager, whooshee
 from flaskbb.utils.populate import (create_test_data, create_welcome_forum,
                                     create_admin_user, create_default_groups,
@@ -114,9 +115,9 @@ def create_admin(username=None, password=None, email=None):
     """Creates the admin user."""
 
     if not (username and password and email):
-        username = unicode(prompt("Username"))
-        email = unicode(prompt("A valid email address"))
-        password = unicode(prompt_pass("Password"))
+        username = to_unicode(prompt("Username"))
+        email = to_unicode(prompt("A valid email address"))
+        password = to_unicode(prompt_pass("Password"))
 
     create_admin_user(username=username, password=password, email=email)
 


### PR DESCRIPTION
My previous PR broke with Py3 (not picked up by the tests) - this fixes it
Also there appeared to be a bug in the compatibility module which didn't convert str to unicode on Py2