### PR TITLE
Fixes #223 Deleting Flagged Post causes 500 INTERNAL SERVER ERROR - tentative fix

### DIFF
--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -98,7 +98,10 @@ class Report(db.Model, CRUDMixin):
     zapped_by = db.Column(db.Integer, db.ForeignKey("users.id"))
     reason = db.Column(db.Text)
 
-    post = db.relationship("Post", backref="report", lazy="joined")
+    post = db.relationship(
+        "Post", lazy="joined",
+        backref=db.backref('report', cascade='all, delete-orphan')
+    )
     reporter = db.relationship("User", lazy="joined",
                                foreign_keys=[reporter_id])
     zapper = db.relationship("User", lazy="joined", foreign_keys=[zapped_by])
@@ -339,14 +342,13 @@ class Topic(db.Model, CRUDMixin):
 
         # If the topic is unread try to get the first unread post
         if topic_is_unread(self, topicsread, user, forumsread):
-            # 
             query = Post.query.filter(Post.topic_id == self.id)
             if topicsread is not None:
                 query = query.filter(Post.date_created > topicsread.last_read)
             post = query.order_by(Post.id.asc()).first()
             if post is not None:
                 return post.url
-        
+
         return self.url
 
     # Methods


### PR DESCRIPTION
In initial testing, I encountered an error that caused the forum view (domain/forum/:slug) to 500 as the initial thread delete got messed up. I have no been able to recreate this issue since then (and that environment is no longer accessible so I cannot revisit it -- for the record it was OSX running 3.7alpha). (see notes below).

I tested this fix under Ubuntu 16.10 + Python 3.6, but I have no reason to believe it is different under other OS/Versions combinations.

QA I performed:

1. Topic starter with report, deleted topic.
2. Reply with a report, deleted post.
3. Reply with a report, deleted topic.
4. Topic starter + reply with reports, deleted topic.
5. Topic starter with multiple reports, deleted topic.
6. Multiple topics in forum, report topic starter in first/last/middle topic, deleted topic.

This seems to completely alleviate the 500s when deleting a post with a report, but I suggest we hammer this fix in an attempt to recreate the forum overview 500 to be safe.

As for the forum overview 500, I can remember this only occurring when a there were 2 topics posted to a forum, a reply to the newest topic was reported, and then the topic was deleted. I have tried several different combinations in my new environment but have been unsuccessful. I won't attribute it to a bad reload as I was able to reproduce it multiple times.

It appeared the topic deleted bugged out and marked the latest thread in a forum as None despite topics still existing in the forum. The exact error was an `AttributeError: NoneType has no such field` when processing the ForumsRead behavior.