### PR TITLE
Add 3.4 and 3.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "3.5"
 # command to install dependencies
 install:
   - "pip install -r requirements-dev.txt"


### PR DESCRIPTION
Despite it being released in the last 24 hours, Travis doesn't look it supports 3.6 yet. :( So I'll add another PR with that when they do add that support.

As an aside, @sh4nks how do you feel about dropping official 3.3 support? 3.3.5 was the last binary release and that was March 4th, 2014. 3.3.6 (Oct 2014) and 3.3.7 (Feb 2016) were source only releases.