### PR TITLE
[BUGFIX] Make `flaskbb install` work with MySQL

### DIFF
--- a/flaskbb/cli/main.py
+++ b/flaskbb/cli/main.py
@@ -97,8 +97,7 @@ def install(welcome, force, username, email, password, group):
             drop_database(db.engine.url)
         else:
             sys.exit(0)
-    if not database_exists(db.engine.url):
-        create_database(db.engine.url)
+    create_database(db.engine.url)
     upgrade_database()
 
     click.secho("[+] Creating default settings...", fg="cyan")

--- a/flaskbb/cli/main.py
+++ b/flaskbb/cli/main.py
@@ -17,7 +17,7 @@ import click
 from werkzeug.utils import import_string, ImportStringError
 from flask import current_app
 from flask.cli import FlaskGroup, ScriptInfo, with_appcontext
-from sqlalchemy_utils.functions import database_exists, drop_database
+from sqlalchemy_utils.functions import database_exists, create_database, drop_database
 from flask_migrate import upgrade as upgrade_database
 
 from flaskbb import create_app
@@ -95,11 +95,11 @@ def install(welcome, force, username, email, password, group):
             "create a new one?", fg="magenta")
         ):
             drop_database(db.engine.url)
-            upgrade_database()
         else:
             sys.exit(0)
-    else:
-        upgrade_database()
+    if not database_exists(db.engine.url):
+        create_database(db.engine.url)
+    upgrade_database()
 
     click.secho("[+] Creating default settings...", fg="cyan")
     create_default_groups()


### PR DESCRIPTION
The install script offers the choice to drop an existing database first.
It then proceeds with the `upgrade` procedure. This doesn't work
(at least) for MySQL. Processing stops with an "Database not found"
error. So let's create the database first if it's missing and then
continue with upgrading.
With this change installation works for me (MariaDB 10.1).