### PR TITLE
'Recent Topics' shows last posted time, not created time

### DIFF
--- a/flaskbb/plugins/portal/templates/index.html
+++ b/flaskbb/plugins/portal/templates/index.html
@@ -123,7 +123,7 @@
               <a href="{{ url_for('user.profile', username=topic.user.username) }}">{{ topic.user.username }}</a>
             </div>
             <div class="portal-topic-updated">
-              {{ topic.date_created | time_since }}
+              {{ topic.last_updated | time_since }}
             </div>
           </div> <!-- /.topic -->
 


### PR DESCRIPTION
As the title says, in the portal plugin the "Recent Topics" box shows topics with their created time.  A couple of my site's users have suggested that might be better as the last updated time.  A genuine one-line fix, for a Friday lunchtime :-)