### PR TITLE
cannot resend verification email as says already verified

### DIFF
--- a/flaskbb/auth/forms.py
+++ b/flaskbb/auth/forms.py
@@ -158,7 +158,7 @@ class RequestActivationForm(FlaskForm):
         if not self.user.username == self.username.data:
             raise ValidationError(_("User does not exist."))
 
-        if self.user.activated is not None:
+        if self.user.activated is True:
             raise ValidationError(_("User is already active."))
 
 


### PR DESCRIPTION
If the verification email fails for whatever reason, every time you try to resend at /auth/activate you get the 'User is already verified" flash. I have confirmed user is not verified in the database and the maintenance panel, and the user cannot log in. I hope i haven't misunderstood, but it looks like a simple logic check needs switching. This appears to work for me. 