### PR TITLE
Editing upgrades

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,py,html,css,less,yml,yaml,json}]
+charset = utf-8
+
+[*.py]
+indent_size = 4
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab
+
+[*.{json,yaml,yml}]
+indent_size = 2
+
+[*.{ini,html}]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,21 @@ node_modules
 
 # Ignore plugins
 flaskbb/plugins/*
+
+# Created by https://www.gitignore.io/api/vim
+
+### Vim ###
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags
+
+# End of https://www.gitignore.io/api/vim


### PR DESCRIPTION
Ignores vim generated files (because I'm a troglodyte) and adds an [editorconfig file](editorconfig.org) so files can be formatted similarly by default. I purposely left off the `max_line_length` setting since it forces a hard line wrap which is unpleasant if you're not expecting it -- I also didn't find an explicit default in any of the usual spots.