### PR TITLE
Add make ctags and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,9 @@ Session.vim
 tags
 
 # End of https://www.gitignore.io/api/vim
+
+# ctags file
+tags
+
+# silver search
+.ignore

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean install help test lint run dependencies docs
+.PHONY: clean install help test lint run dependencies docs ctags
 
 help:
 	@echo "  clean      remove unwanted stuff"
@@ -8,6 +8,7 @@ help:
 	@echo "  lint       check the source for style errors"
 	@echo "  run        run the development server with the development config"
 	@echo "  docs       build the documentation"
+	@echo "  ctags	    creates a ctags file of Flaskbb's main files"
 
 dependencies:requirements.txt
 	pip install -r requirements.txt
@@ -39,3 +40,14 @@ lint:check
 
 check:
 	@type flake8 >/dev/null 2>&1 || echo "Flake8 is not installed. You can install it with 'pip install flake8'."
+
+ctags:
+	ctags \
+	--verbose -R -f tags \
+	--exclude=.tx \
+	--exclude=.git \
+	--exclude=tests \
+	--exclude=whoosh_index \
+	--exclude=docs \
+	--exclude=FlaskBB.egg-info \
+	.


### PR DESCRIPTION
Adds make ctags for generating a ctags file, useful for jump navigation in non-IDE editors, and updates the .gitignore file for the generated file and to ignore the silver search .ignore file