### PR TITLE
Messages: consistent quota (fixes #337) + stay in trash after op in trash

### DIFF
--- a/flaskbb/message/views.py
+++ b/flaskbb/message/views.py
@@ -87,7 +87,7 @@ class ViewConversation(MethodView):
         form = self.form()
         return render_template("message/conversation.html", conversation=conversation, form=form)
 
-    @requires_message_box_space
+    #@requires_message_box_space
     def post(self, conversation_id):
         conversation = Conversation.query.filter_by(
             id=conversation_id, user_id=current_user.id
@@ -302,7 +302,7 @@ class RestoreConversation(MethodView):
 
         conversation.trash = False
         conversation.save()
-        return redirect(url_for("message.inbox"))
+        return redirect(url_for("message.trash"))
 
 
 class DeleteConversation(MethodView):
@@ -314,7 +314,7 @@ class DeleteConversation(MethodView):
         ).first_or_404()
 
         conversation.delete()
-        return redirect(url_for("message.inbox"))
+        return redirect(url_for("message.trash"))
 
 
 class SentMessages(MethodView):


### PR DESCRIPTION
Fix #337 Private messages: quota inconsistent (alternative 1)
* Private message quota was handled inconsistently. Replying in existing conversations was not counted towards the quota as long as the quota is not reached. However, as soon as the quota is reached or exceeded, replying to an existing conversation was not possible anymore. Fixed, so that replies to existing conversations are always possible.

Private messages: Redirect to trash after doing operations in trash folder