### PR TITLE
Allow disabling of private messages

### DIFF
--- a/flaskbb/fixtures/settings.py
+++ b/flaskbb/fixtures/settings.py
@@ -152,7 +152,7 @@ fixture = (
                 'value_type':   "integer",
                 'extra':        {"min": 0},
                 'name':         "Private Message Quota",
-                'description':  "The amount of messages a user can have."
+                'description':  "The amount of messages a user can have. 0 to disable private messages."
             }),
             ('online_last_minutes', {
                 'value':        15,

--- a/flaskbb/message/views.py
+++ b/flaskbb/message/views.py
@@ -26,6 +26,17 @@ from flaskbb.utils.settings import flaskbb_config
 
 message = Blueprint("message", __name__)
 
+def requires_private_messages_enabled(f):
+
+    @wraps(f)
+    def wrapper(*a, **k):
+        if not flaskbb_config['MESSAGE_QUOTA']:
+            flash(_("Private messages are disabled for this board."), "danger")
+            return redirect(url_for("forum.index"))
+        return f(*a, **k)
+
+    return wrapper
+
 
 def requires_message_box_space(f):
 
@@ -47,7 +58,7 @@ def requires_message_box_space(f):
 
 
 class Inbox(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def get(self):
         page = request.args.get('page', 1, type=int)
@@ -71,7 +82,7 @@ class Inbox(MethodView):
 
 
 class ViewConversation(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
     form = MessageForm
 
     def get(self, conversation_id):
@@ -133,7 +144,7 @@ class ViewConversation(MethodView):
 
 
 class NewConversation(MethodView):
-    decorators = [requires_message_box_space, login_required]
+    decorators = [requires_message_box_space, requires_private_messages_enabled, login_required]
     form = ConversationForm
 
     def get(self):
@@ -193,7 +204,7 @@ class NewConversation(MethodView):
 
 
 class EditConversation(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
     form = ConversationForm
 
     def get(self, conversation_id):
@@ -263,7 +274,7 @@ class EditConversation(MethodView):
 
 
 class RawMessage(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def get(self, message_id):
 
@@ -279,7 +290,7 @@ class RawMessage(MethodView):
 
 
 class MoveConversation(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def post(self, conversation_id):
         conversation = Conversation.query.filter_by(
@@ -293,7 +304,7 @@ class MoveConversation(MethodView):
 
 
 class RestoreConversation(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def post(self, conversation_id):
         conversation = Conversation.query.filter_by(
@@ -306,7 +317,7 @@ class RestoreConversation(MethodView):
 
 
 class DeleteConversation(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def post(self, conversation_id):
         conversation = Conversation.query.filter_by(
@@ -318,7 +329,7 @@ class DeleteConversation(MethodView):
 
 
 class SentMessages(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def get(self):
 
@@ -344,7 +355,7 @@ class SentMessages(MethodView):
 
 
 class DraftMessages(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def get(self):
 
@@ -369,7 +380,7 @@ class DraftMessages(MethodView):
 
 
 class TrashedMessages(MethodView):
-    decorators = [login_required]
+    decorators = [requires_private_messages_enabled, login_required]
 
     def get(self):
 

--- a/flaskbb/templates/layout.html
+++ b/flaskbb/templates/layout.html
@@ -83,6 +83,7 @@
                         <ul class="nav navbar-nav navbar-right">
 
                             {% if current_user and current_user.is_authenticated %}
+                            {% if flaskbb_config["MESSAGE_QUOTA"] > 0 %}
                             <!-- Inbox -->
                             <li class="dropdown {{ is_active('message.inbox') }}">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -111,6 +112,7 @@
                                     <li><a href="{{ url_for('message.new_conversation') }}"><span class="fa fa-pencil fa-fw"></span> {% trans %}New Message{% endtrans %}</a></li>
                                 </ul>
                             </li>
+                            {% endif %}
 
                             <!-- User Menu -->
                             <li>


### PR DESCRIPTION
When 0 is set as private message quota, private messages are disabled.
* This is shown in the settings.
* When private messages are disabled, the field does not appear in the navigation bar.