### PR TITLE
Allow guest to posts (fixes #343)

### DIFF
--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -207,8 +207,11 @@ class Post(HideableCRUDMixin, db.Model):
         # Adding a new post
         if user and topic:
             created = time_utcnow()
-            self.user = user
-            self.username = user.username
+            if isinstance(user, db.Model):
+                self.user = user
+                self.username = user.username
+            else:
+                self.username = ""
             self.topic = topic
             self.date_created = created
 
@@ -220,11 +223,15 @@ class Post(HideableCRUDMixin, db.Model):
                 topic.forum.last_post = self
                 topic.forum.last_post_user = self.user
                 topic.forum.last_post_title = topic.title
-                topic.forum.last_post_username = user.username
+                if isinstance(user, db.Model):
+                    topic.forum.last_post_username = user.username
+                else:
+                    topic.forum.last_post_username = ""
                 topic.forum.last_post_created = created
 
                 # Update the post counts
-                user.post_count += 1
+                if isinstance(user, db.Model):
+                    user.post_count += 1
                 topic.post_count += 1
                 topic.forum.post_count += 1
 

--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -210,7 +210,7 @@ class Post(HideableCRUDMixin, db.Model):
             if isinstance(user, db.Model):
                 self.user = user
                 self.username = user.username
-            else:
+            else: # needed to prevent database integrity error (username must not be NULL)
                 self.username = ""
             self.topic = topic
             self.date_created = created
@@ -633,8 +633,11 @@ class Topic(HideableCRUDMixin, db.Model):
 
         # Set the forum and user id
         self.forum = forum
-        self.user = user
-        self.username = user.username
+        if isinstance(user, db.Model):
+            self.user = user
+            self.username = user.username
+        else: # needed to prevent database integrity error (username must not be NULL)
+            self.username = ""
 
         # Set the last_updated time. Needed for the readstracker
         self.date_created = self.last_updated = time_utcnow()

--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -207,7 +207,7 @@ class Post(HideableCRUDMixin, db.Model):
         # Adding a new post
         if user and topic:
             created = time_utcnow()
-            if isinstance(user, db.Model):
+            if user.is_authenticated:
                 self.user = user
                 self.username = user.username
             else:
@@ -225,14 +225,14 @@ class Post(HideableCRUDMixin, db.Model):
                 topic.forum.last_post = self
                 topic.forum.last_post_user = self.user
                 topic.forum.last_post_title = topic.title
-                if isinstance(user, db.Model):
+                if user.is_authenticated:
                     topic.forum.last_post_username = user.username
                 else:
                     topic.forum.last_post_username = ""
                 topic.forum.last_post_created = created
 
                 # Update the post counts
-                if isinstance(user, db.Model):
+                if user.is_authenticated:
                     user.post_count += 1
                 topic.post_count += 1
                 topic.forum.post_count += 1
@@ -635,7 +635,7 @@ class Topic(HideableCRUDMixin, db.Model):
 
         # Set the forum and user id
         self.forum = forum
-        if isinstance(user, db.Model):
+        if user.is_authenticated:
             self.user = user
             self.username = user.username
         else:

--- a/flaskbb/forum/models.py
+++ b/flaskbb/forum/models.py
@@ -210,7 +210,9 @@ class Post(HideableCRUDMixin, db.Model):
             if isinstance(user, db.Model):
                 self.user = user
                 self.username = user.username
-            else: # needed to prevent database integrity error (username must not be NULL)
+            else:
+                # treat guest users separately
+                # "" because username must not be NULL (database constaint)
                 self.username = ""
             self.topic = topic
             self.date_created = created
@@ -636,7 +638,9 @@ class Topic(HideableCRUDMixin, db.Model):
         if isinstance(user, db.Model):
             self.user = user
             self.username = user.username
-        else: # needed to prevent database integrity error (username must not be NULL)
+        else:
+            # treat guest users separately
+            # needed to prevent database integrity error (username must not be NULL)
             self.username = ""
 
         # Set the last_updated time. Needed for the readstracker

--- a/flaskbb/forum/views.py
+++ b/flaskbb/forum/views.py
@@ -189,7 +189,6 @@ class ViewTopic(MethodView):
 
 
 class NewTopic(MethodView):
-    decorators = [login_required]
     form = NewTopicForm
 
     def get(self, forum_id, slug=None):

--- a/flaskbb/forum/views.py
+++ b/flaskbb/forum/views.py
@@ -189,13 +189,13 @@ class ViewTopic(MethodView):
 
 
 class NewTopic(MethodView):
+    decorators = [allows.requires(CanPostTopic)]
     form = NewTopicForm
 
     def get(self, forum_id, slug=None):
         forum_instance = Forum.query.filter_by(id=forum_id).first_or_404()
         return render_template('forum/new_topic.html', forum=forum_instance, form=self.form())
 
-    @allows.requires(CanPostTopic)
     def post(self, forum_id, slug=None):
         forum_instance = Forum.query.filter_by(id=forum_id).first_or_404()
         form = self.form()

--- a/flaskbb/management/views.py
+++ b/flaskbb/management/views.py
@@ -507,10 +507,8 @@ class DeleteGroup(MethodView):
         if group_id is not None:
             if group_id <= 5:  # there are 5 standard groups
                 flash(
-                    _(
-                        "You cannot delete the standard groups. "
-                        "Try renaming it instead.", "danger"
-                    )
+                    _("You cannot delete the standard groups. Try renaming it instead."),
+                    "danger"
                 )
                 return redirect(url_for("management.groups"))
 

--- a/flaskbb/management/views.py
+++ b/flaskbb/management/views.py
@@ -507,7 +507,7 @@ class DeleteGroup(MethodView):
         if group_id is not None:
             if group_id <= 5:  # there are 5 standard groups
                 flash(
-                    _("You cannot delete the standard groups. Try renaming it instead."),
+                    _("You cannot delete the standard groups. Try renaming instead."),
                     "danger"
                 )
                 return redirect(url_for("management.groups"))


### PR DESCRIPTION
This is an attempt to fix the immediate errors that result when a guest is allowed to reply/post and actually tries to do so. While I don’t think there would be many forums that would allow guests to post (and we should therefore not spend too much time working on this), I do think that given the current permission system, #343 is a bug that should be fixed.

Now, it is arguable whether it is a good idea to save "" as username and None as user_id, but I wanted to get some input first, hence this pull request. (By the way: If you prefer discussing in the issue or squashing the commits before making the pull request, just tell me that. I’m completely new to both Git and Github.)

**Alternative approach**
It might be more suitable to make Guest inherit from User and create a standard (non-deletable?) guest user that these posts are then assigned to. In that case, we could maybe also deal with the problem of the username in that a Guest class has a username attribute that when retrieved actually calls Babel’s gettext function, so it can be translated. But then: How do we know that when we load a user from the database, it should be instantiated as Guest, rather than as User? So, I think this solution would cause a bit more of a headache than it’s worth.

**Left to do with the current approach**
The "" (not) showing up in the forums for guest posts look ugly at the very least. I just had the following idea: Since everyone else has to have a username that is at least one character long, we might actually check in the template for "" as username and dynamically replace it with _("Guest").

**One last thing**
Before I forget: The first commit "Mismatched parentheses" (flaskbb/management/views.py) has nothing to do with this, but also caused a 500 when trying to delete a standard group (id < 6). I hope it’s presence is not a problem.