### PR TITLE
Make 'flaskbb upgrade fixture' return correct number of settings changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ Session.vim
 tags
 
 # End of https://www.gitignore.io/api/vim
+
+htmlcov/

--- a/flaskbb/cli/main.py
+++ b/flaskbb/cli/main.py
@@ -225,8 +225,8 @@ def upgrade(all_latest, fixture, force):
         count = update_settings_from_fixture(
             fixture=settings, overwrite_group=force, overwrite_setting=force
         )
-        click.secho("[+] {} groups and {} settings updated.".format(
-            len(count.keys()), len(count.values())), fg="green"
+        click.secho("[+] {settings} settings in {groups} setting groups updated.".format(
+            groups=len(count), settings=sum([len(settings) for settings in count.values()])), fg="green"
         )
 
 

--- a/flaskbb/cli/main.py
+++ b/flaskbb/cli/main.py
@@ -226,7 +226,7 @@ def upgrade(all_latest, fixture, force):
             fixture=settings, overwrite_group=force, overwrite_setting=force
         )
         click.secho("[+] {settings} settings in {groups} setting groups updated.".format(
-            groups=len(count), settings=sum([len(settings) for settings in count.values()])), fg="green"
+            groups=len(count), settings=sum(len(settings) for settings in count.values())), fg="green"
         )
 
 

--- a/flaskbb/utils/populate.py
+++ b/flaskbb/utils/populate.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals
+import collections
 from flaskbb.management.models import Setting, SettingsGroup
 from flaskbb.user.models import User, Group
 from flaskbb.forum.models import Post, Topic, Forum, Category
@@ -85,7 +86,7 @@ def update_settings_from_fixture(fixture, overwrite_group=False,
                               setting if it already exists.
                               Defaults to ``False``.
     """
-    updated_settings = {}
+    updated_settings = collections.defaultdict(list)
 
     for settingsgroup in fixture:
 
@@ -130,10 +131,7 @@ def update_settings_from_fixture(fixture, overwrite_group=False,
                     )
 
                 setting.save()
-                try:
-                    updated_settings[group].append(setting)
-                except KeyError:
-                    updated_settings[group] = [setting]
+                updated_settings[group].append(setting)
     return updated_settings
 
 

--- a/flaskbb/utils/populate.py
+++ b/flaskbb/utils/populate.py
@@ -110,8 +110,17 @@ def update_settings_from_fixture(fixture, overwrite_group=False,
 
             setting = Setting.query.filter_by(key=settings[0]).first()
 
-            if (setting is not None and overwrite_setting) or setting is None:
+            if setting is not None:
+                setting_is_different = (
+                    setting.value != settings[1]["value"]
+                    or setting.value_type != settings[1]["value_type"]
+                    or setting.name != settings[1]["name"]
+                    or setting.description != settings[1]["description"]
+                    or setting.extra != settings[1].get("extra", "")
+                    or setting.settingsgroup != group.key
+                )
 
+            if (setting is not None and overwrite_setting and setting_is_different) or setting is None:
                 if setting is not None:
                     setting.value = settings[1]["value"]
                     setting.value_type = settings[1]["value_type"]

--- a/flaskbb/utils/populate.py
+++ b/flaskbb/utils/populate.py
@@ -130,8 +130,10 @@ def update_settings_from_fixture(fixture, overwrite_group=False,
                     )
 
                 setting.save()
-                updated_settings[group] = []
-                updated_settings[group].append(setting)
+                try:
+                    updated_settings[group].append(setting)
+                except KeyError:
+                    updated_settings[group] = [setting]
     return updated_settings
 
 

--- a/tests/unit/utils/test_populate.py
+++ b/tests/unit/utils/test_populate.py
@@ -31,42 +31,159 @@ def test_create_settings_from_fixture(database):
 
 
 def test_update_settings_from_fixture(database):
-    # No force-overwrite - the fixtures will be created because
-    # do not exist.
+    def individual_settings(update_result):
+        """helper that returns the number of settings that were updated"""
+        return sum(len(settings_in_a_group) for settings_in_a_group in update_result.values())
+
+    settings_fixture_group_count = len(settings_fixture)
+    settings_fixture_setting_count = sum(
+        len(settings_fixture[k][1]['settings']) for k in range(len(settings_fixture))
+    )
+
+
     assert not SettingsGroup.query.count()
     assert not Setting.query.count()
-    updated = update_settings_from_fixture(settings_fixture)
-    assert len(updated) == SettingsGroup.query.count()
 
-    # force-overwrite - the fixtures exist, but they will be overwritten now.
-    force_updated = update_settings_from_fixture(settings_fixture,
-                                                 overwrite_group=True,
-                                                 overwrite_setting=True)
-    assert len(force_updated) == SettingsGroup.query.count()
+    # No force-overwrite - the fixtures will be created because they do not exist.
+    updated_1 = update_settings_from_fixture(settings_fixture)
+    assert settings_fixture_group_count == len(updated_1)
+    assert settings_fixture_group_count == SettingsGroup.query.count()
+    assert settings_fixture_setting_count == individual_settings(updated_1)
+    assert settings_fixture_setting_count == Setting.query.count()
 
-    updated_fixture = (
+    # force-overwrite - nothing changed so nothing should happen here
+    force_updated_1 = update_settings_from_fixture(settings_fixture,
+                                                   overwrite_group=True,
+                                                   overwrite_setting=True)
+
+    assert len(force_updated_1) == 0
+    assert individual_settings(force_updated_1) == 0
+    assert settings_fixture_group_count == SettingsGroup.query.count()
+    assert settings_fixture_setting_count == Setting.query.count()
+
+    fixture_to_update_with = (
+        # a group where we change a lot
         ('general', {
             'name': "General Settings",
-            'description': "How many items per page are displayed.",
+            'description': "This description is wrong.",
             'settings': (
+                # change value
                 ('project_title', {
-                    'value': "FlaskBB",
+                    'value': "FlaskBB is cool!",
                     'value_type': "string",
                     'name': "Project title",
                     'description': "The title of the project.",
                 }),
+                # change name
+                ('project_subtitle', {
+                    'value':        "A lightweight forum software in Flask",
+                    'value_type':   "string",
+                    'name':         "Subtitle of the project",
+                    'description':  "A short description of the project.",
+                }),
+                # change options (extra)
+                ('posts_per_page', {
+                    'value':        10,
+                    'value_type':   "integer",
+                    'extra':        {'min': 1},
+                    'name':         "Posts per page",
+                    'description':  "Number of posts displayed per page.",
+                }),
+                # change description
+                ('topics_per_page', {
+                    'value':        10,
+                    'value_type':   "integer",
+                    'extra':        {'min': 5},
+                    'name':         "Topics per page",
+                    'description':  "The number of topics to be displayed per page.",
+                }),
+                # add
                 ('test_fixture', {
                     'description': 'This is a test fixture',
                     'name': 'Test Fixture',
                     'value': 'FlaskBBTest',
                     'value_type': 'string'
-                })
+                }),
             )
         }),
+        # a group where we change nothing
+        ('auth', {
+            'name': 'Authentication Settings',
+            'description': 'Configurations for the Login and Register process!',
+            # the same as in flaskbb/settings/fixtures/settings.py
+            'settings': (
+                ('registration_enabled', {
+                    'value':        True,
+                    'value_type':   "boolean",
+                    'name':         "Enable Registration",
+                    'description':  "Enable or disable the registration",
+                }),
+            )
+        }),
+        # a wholly new group
+        ('testgroup', {
+            'name': "Important settings",
+            'description': "Some settings without which the world would not work.",
+            'settings': (
+                # change value
+                ('monty_python', {
+                    'value': "And now for something completely different…",
+                    'value_type': "string",
+                    'name': "Monty Python",
+                    'description': "A random quote from Monty Python.",
+                }),
+            )
+        })
     )
 
-    updated = update_settings_from_fixture(updated_fixture)
-    assert len(updated) == 1
+    # should add groups: testgroup
+    # should add testgroup/monty_python, general/test_fixture
+    updated_2 = update_settings_from_fixture(fixture_to_update_with)
+    assert len(updated_2) == 2
+    assert individual_settings(updated_2) == 2
+    assert settings_fixture_group_count + 1 == SettingsGroup.query.count()
+    assert settings_fixture_setting_count + 2 == Setting.query.count()
+
+    fixture_to_update_with[2][1]['settings'][0][1]['description'] = "Something meaningless."
+
+    # should update groups: general
+    # should update settings: 4 in general, 1 in testgroup
+    force_updated_2 = update_settings_from_fixture(fixture_to_update_with,
+                                                   overwrite_group=True,
+                                                   overwrite_setting=True)
+    assert len(force_updated_2) == 2
+    assert individual_settings(force_updated_2) == 5
+    assert settings_fixture_group_count + 1 == SettingsGroup.query.count()
+    assert settings_fixture_setting_count + 2 == Setting.query.count()
+
+    modified_settings_fixture = [item for item in settings_fixture]
+    modified_settings_fixture.append(
+        # another wholly new group
+        ('testgroup2', {
+            'name': "Important settings",
+            'description': "Some settings without which the world would not work.",
+            'settings': (
+                # change value
+                ('monty_python_reborn', {
+                    'value': "And now for something completely different…",
+                    'value_type': "string",
+                    'name': "Monty Python",
+                    'description': "A random quote from Monty Python.",
+                }),
+            )
+        })
+    )
+
+    # should revert 4 in general
+    # should add testgroup2 and one subitem
+    force_updated_3 = update_settings_from_fixture(modified_settings_fixture,
+                                                   overwrite_group=True,
+                                                   overwrite_setting=True)
+
+    assert len(force_updated_3) == 2
+    assert individual_settings(force_updated_3) == 5
+    assert settings_fixture_group_count + 2 == SettingsGroup.query.count()
+    assert settings_fixture_setting_count + 3 == Setting.query.count()
 
 
 def test_create_user(default_groups):

--- a/tests/unit/utils/test_populate.py
+++ b/tests/unit/utils/test_populate.py
@@ -127,7 +127,7 @@ def test_update_settings_from_fixture(database):
             'settings': (
                 # change value
                 ('monty_python', {
-                    'value': "And now for something completely different…",
+                    'value': "And now for something completely different...",
                     'value_type': "string",
                     'name': "Monty Python",
                     'description': "A random quote from Monty Python.",
@@ -165,7 +165,7 @@ def test_update_settings_from_fixture(database):
             'settings': (
                 # change value
                 ('monty_python_reborn', {
-                    'value': "And now for something completely different…",
+                    'value': "And now for something completely different...",
                     'value_type': "string",
                     'name': "Monty Python",
                     'description': "A random quote from Monty Python.",


### PR DESCRIPTION
Fixes #345, where 'flaskbb upgrade fixture' would return the number of settings groups it touched where it should have returned the number of individual settings.