### PR TITLE
Bug in cli

### DIFF
--- a/flaskbb/cli/main.py
+++ b/flaskbb/cli/main.py
@@ -107,9 +107,7 @@ flaskbb.add_command(alembic_click, "db")
 @click.option("--email", "-e", type=EmailType(),
               help="The email address of the user.")
 @click.option("--password", "-p", help="The password of the user.")
-@click.option("--group", "-g", help="The group of the user.",
-              type=click.Choice(["admin", "super_mod", "mod", "member"]))
-def install(welcome, force, username, email, password, group):
+def install(welcome, force, username, email, password):
     """Installs flaskbb. If no arguments are used, an interactive setup
     will be run.
     """
@@ -130,7 +128,7 @@ def install(welcome, force, username, email, password, group):
     create_default_settings()
 
     click.secho("[+] Creating admin user...", fg="cyan")
-    prompt_save_user(username, email, password, group)
+    prompt_save_user(username, email, password, "admin")
 
     if welcome:
         click.secho("[+] Creating welcome forum...", fg="cyan")

--- a/flaskbb/cli/users.py
+++ b/flaskbb/cli/users.py
@@ -56,7 +56,7 @@ def new_user(username, email, password, group):
 def change_user(username, password, email, group):
     """Updates an user. Omit any options to use the interactive mode."""
 
-    user = prompt_save_user(username, password, email, group)
+    user = prompt_save_user(username, password, email, group, only_update=True)
     if user is None:
         raise FlaskBBCLIError("The user with username {} does not exist."
                               .format(username), fg="red")


### PR DESCRIPTION
When installing via the CLI, it is possible to create the admin user without admin rights. Additionally if you then realise your mistake and try to edit the user in the command line it attempts to add the same user again and fails. 
You can of course add admin users subsequently from the CLI so this doesn't brick the whole installation but I think that the user created during the install script should be forced to be an admin user