### PR TITLE
Ignore misspelled/invalid lexer names in code blocks (fixes #355)

### DIFF
--- a/flaskbb/utils/markup.py
+++ b/flaskbb/utils/markup.py
@@ -17,6 +17,7 @@ import mistune
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
+from pygments.util import ClassNotFound
 
 
 _re_emoji = re.compile(r':([a-z0-9\+\-_]+):', re.I)
@@ -88,10 +89,16 @@ class FlaskBBRenderer(mistune.Renderer):
         return '<p>%s</p>\n' % text.strip(' ')
 
     def block_code(self, code, lang):
-        if not lang:
+        if lang:
+            try:
+                lexer = get_lexer_by_name(lang, stripall=True)
+            except ClassNotFound:
+                lexer = None
+        else:
+            lexer = None
+        if not lexer:
             return '\n<pre><code>%s</code></pre>\n' % \
                 mistune.escape(code)
-        lexer = get_lexer_by_name(lang, stripall=True)
         formatter = HtmlFormatter()
         return highlight(code, lexer, formatter)
 

--- a/tests/unit/utils/test_markup.py
+++ b/tests/unit/utils/test_markup.py
@@ -25,3 +25,14 @@ print("Hello World")
 
     assert "<pre>" in markdown.render(b_plain)
     assert "highlight" in markdown.render(b_plain_lang)
+
+    # typo in language
+    bad_language = """
+```notpython
+print("Hello World")
+```
+"""
+
+    bad_language_render = markdown.render(bad_language)
+    assert "<pre>" in bad_language_render
+    assert "highlight" not in bad_language_render


### PR DESCRIPTION
Catches ClassNotFound from pygments in FlaskBBRenderer::block_code and ignores it, returning unhighlighted code. Fixes #355