### PR TITLE
Make template hooks into jinja contextfunctions

### DIFF
--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -66,7 +66,7 @@ def flaskbb_cli(cli):
 # Template Hooks
 
 @spec
-def flaskbb_tpl_before_navigation():
+def flaskbb_tpl_before_navigation(context):
     """Hook for registering additional navigation items.
 
     in :file:`templates/layout.html`.
@@ -74,7 +74,7 @@ def flaskbb_tpl_before_navigation():
 
 
 @spec
-def flaskbb_tpl_after_navigation():
+def flaskbb_tpl_after_navigation(context):
     """Hook for registering additional navigation items.
 
     in :file:`templates/layout.html`.
@@ -82,7 +82,7 @@ def flaskbb_tpl_after_navigation():
 
 
 @spec
-def flaskbb_tpl_before_registration_form():
+def flaskbb_tpl_before_registration_form(context):
     """This hook is emitted in the Registration form **before** the first
     input field but after the hidden CSRF token field.
 
@@ -91,7 +91,7 @@ def flaskbb_tpl_before_registration_form():
 
 
 @spec
-def flaskbb_tpl_after_registration_form():
+def flaskbb_tpl_after_registration_form(context):
     """This hook is emitted in the Registration form **after** the last
     input field but before the submit field.
 
@@ -100,7 +100,7 @@ def flaskbb_tpl_after_registration_form():
 
 
 @spec
-def flaskbb_tpl_before_user_details_form():
+def flaskbb_tpl_before_user_details_form(context):
     """This hook is emitted in the Change User Details form **before** an
     input field is rendered.
 
@@ -109,7 +109,7 @@ def flaskbb_tpl_before_user_details_form():
 
 
 @spec
-def flaskbb_tpl_after_user_details_form():
+def flaskbb_tpl_after_user_details_form(context):
     """This hook is emitted in the Change User Details form **after** the last
     input field has been rendered but before the submit field.
 

--- a/flaskbb/plugins/utils.py
+++ b/flaskbb/plugins/utils.py
@@ -10,15 +10,15 @@
     :license: BSD, see LICENSE for more details.
 """
 from flask import current_app, flash, redirect, url_for
-from jinja2 import Markup
+from jinja2 import Markup,contextfunction
 from flask_babelplus import gettext as _
 
 from flaskbb.extensions import db
 from flaskbb.utils.datastructures import TemplateEventResult
 from flaskbb.plugins.models import PluginRegistry
 
-
-def template_hook(name, silent=True, **kwargs):
+@contextfunction
+def template_hook(ctx,name, silent=True, **kwargs):
     """Calls the given template hook.
 
     :param name: The name of the hook.
@@ -26,6 +26,7 @@ def template_hook(name, silent=True, **kwargs):
                    doesn't exist. Defauls to ``True``.
     :param kwargs: Additional kwargs that should be passed to the hook.
     """
+    kwargs['context']=ctx
     try:
         hook = getattr(current_app.pluggy.hook, name)
         result = hook(**kwargs)


### PR DESCRIPTION
The before/after user details and before/after registration hooks inject code before and after the form fields between the `<form></form>` tags. 
It would be helpful if plugins could request access to the template context (in this case in particular, the `form` variable so they did not have to independently recreate the form).

 