### PR TITLE
Allow plugins to register profile settings links

### DIFF
--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -436,6 +436,8 @@ def load_plugins(app):
     registered_names = set([p.name for p in plugins])
     unregistered = [
         PluginRegistry(name=name) for name in loaded_names - registered_names
+        # ignore internal FlaskBB modules
+        if not name.startswith('flaskbb.') and name != 'flaskbb'
     ]
     with app.app_context():
         db.session.add_all(unregistered)

--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -11,6 +11,7 @@
 import os
 import logging
 import logging.config
+import sys
 import time
 from functools import partial
 
@@ -406,6 +407,17 @@ def configure_mail_logs(app):
 
 def load_plugins(app):
     app.pluggy.add_hookspecs(spec)
+
+    # have to find all the flaskbb modules that are loaded this way
+    # otherwise sys.modules might change while we're iterating it
+    # because of imports and that makes Python very unhappy
+    flaskbb_modules = [
+        module for name, module in sys.modules.items()
+        if name.startswith('flaskbb')
+    ]
+    for module in flaskbb_modules:
+        app.pluggy.register(module)
+
     try:
         with app.app_context():
             plugins = PluginRegistry.query.all()

--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -115,3 +115,32 @@ def flaskbb_tpl_after_user_details_form():
 
     in :file:`templates/user/change_user_details.html`.
     """
+
+@spec
+def flaskbb_tpl_profile_settings_menu():
+    """This hook is emitted on the user settings page in order to populate the
+    side bar menu. Implementations of this hook should return a list of tuples
+    that are view name and display text. The display text will be provided to
+    the translation service so it is unnecessary to supply translated text.
+
+    A plugin can declare a new block by setting the view to None. If this is
+    done, consider marking the hook implementation with `trylast=True` to
+    avoid capturing plugins that do not create new blocks.
+
+    For example:
+
+        @impl(trylast=True)
+        def flaskbb_tpl_profile_settings_menu():
+            return [
+                (None, 'Account Settings'),
+                ('user.settings', 'General Settings'),
+                ('user.change_user_details', 'Change User Details'),
+                ('user.change_email', 'Change E-Mail Address'),
+                ('user.change_password', 'Change Password')
+            ]
+
+    Hookwrappers for this spec should not be registered as FlaskBB
+    supplies its own hookwrapper to flatten all the lists into a single list.
+
+    in :file:`templates/user/settings_layout.html`
+    """

--- a/flaskbb/plugins/utils.py
+++ b/flaskbb/plugins/utils.py
@@ -24,6 +24,9 @@ def template_hook(name, silent=True, is_markup=True, **kwargs):
     :param name: The name of the hook.
     :param silent: If set to ``False``, it will raise an exception if a hook
                    doesn't exist. Defauls to ``True``.
+    :param is_markup: Determines if the hook should return a Markup object or not.
+                      Setting to False returns a TemplateEventResult object. The
+                      default is True.
     :param kwargs: Additional kwargs that should be passed to the hook.
     """
     try:

--- a/flaskbb/plugins/utils.py
+++ b/flaskbb/plugins/utils.py
@@ -18,7 +18,7 @@ from flaskbb.utils.datastructures import TemplateEventResult
 from flaskbb.plugins.models import PluginRegistry
 
 
-def template_hook(name, silent=True, **kwargs):
+def template_hook(name, silent=True, is_markup=True, **kwargs):
     """Calls the given template hook.
 
     :param name: The name of the hook.
@@ -28,13 +28,16 @@ def template_hook(name, silent=True, **kwargs):
     """
     try:
         hook = getattr(current_app.pluggy.hook, name)
-        result = hook(**kwargs)
+        result = TemplateEventResult(hook(**kwargs))
     except AttributeError:  # raised if hook doesn't exist
         if silent:
             return ""
         raise
 
-    return Markup(TemplateEventResult(result))
+    if is_markup:
+        return Markup(result)
+
+    return result
 
 
 def validate_plugin(name):

--- a/flaskbb/templates/user/settings_layout.html
+++ b/flaskbb/templates/user/settings_layout.html
@@ -14,7 +14,7 @@
             <ul class="nav sidenav">
                 {% for view, text in run_hook('flaskbb_tpl_profile_settings_menu', is_markup=False) %}
                         {% if view == None %}
-                        <li class="sidenav-header">{% trans header=text %}{{ text }}{% endtrans %}</li>
+                        <li class="sidenav-header">{{ _(text) }}</li>
                         {% else %}
                         {{ navlink(view, _(text)) }}
                         {% endif %}

--- a/flaskbb/templates/user/settings_layout.html
+++ b/flaskbb/templates/user/settings_layout.html
@@ -12,11 +12,13 @@
     <div class="col-sm-3">
         <div class="sidebar">
             <ul class="nav sidenav">
-                <li class="sidenav-header">{% trans %}Account Settings{% endtrans %}</li>
-                {{ navlink('user.settings', _('General Settings')) }}
-                {{ navlink('user.change_user_details', _('Change User Details')) }}
-                {{ navlink('user.change_email', _('Change E-Mail Address')) }}
-                {{ navlink('user.change_password', _('Change Password')) }}
+                {% for view, text in run_hook('flaskbb_tpl_profile_settings_menu', is_markup=False) %}
+                        {% if view == None %}
+                        <li class="sidenav-header">{% trans header=text %}{{ text }}{% endtrans %}</li>
+                        {% else %}
+                        {{ navlink(view, _(text)) }}
+                        {% endif %}
+                {% endfor %}
             </ul>
         </div>
     </div><!--/.col-sm-3 -->

--- a/flaskbb/user/__init__.py
+++ b/flaskbb/user/__init__.py
@@ -1,3 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+    flaskbb.user
+    ~~~~~~~~~~~~~~~
+
+    This module contains models, forms and views relevant to Users
+
+    :copyright: (c) 2014 by the FlaskBB Team.
+    :license: BSD, see LICENSE for more details.
+"""
 import logging
+
+# force plugins to be loaded
+from . import plugins
 
 logger = logging.getLogger(__name__)

--- a/flaskbb/user/plugins.py
+++ b/flaskbb/user/plugins.py
@@ -1,0 +1,22 @@
+from itertools import chain
+from pluggy import HookimplMarker
+
+impl = HookimplMarker('flaskbb')
+
+
+@impl(hookwrapper=True, tryfirst=True)
+def flaskbb_tpl_profile_settings_menu():
+    """
+    Flattens the lists that come back from the hook
+    into a single iterable that can be used to populate
+    the menu
+    """
+    results = [
+        (None, 'Account Settings'),
+        ('user.settings', 'General Settings'),
+        ('user.change_user_details', 'Change User Details'),
+        ('user.change_email', 'Change E-Mail Address'),
+        ('user.change_password', 'Change Password')
+    ]
+    outcome = yield
+    outcome.force_result(chain(results, *outcome.get_result()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ MarkupSafe==1.0
 mistune==0.7.4
 olefile==0.44
 Pillow==4.0.0
-pluggy==0.5.1
+pluggy==0.6
 Pygments==2.2.0
 python-editor==1.0.3
 pytz==2017.2


### PR DESCRIPTION
Hopefully closes #368 

@djsilcock Gonna ping you here directly to take a look as well

Allows plugins to register blocks and links in the User profile settings links. Here is a screenshot with a "Some Other Settings" block registered with a link to the forum index under it -- a completely synthetic example for sure, but this is completely constructed from the plugin system.

![user_settings_plugin](https://user-images.githubusercontent.com/4221605/33699501-7fbf959e-dae1-11e7-8e32-19f4d4c9c133.png)

A few changes:

1. The plugin loader will now inspect all FlaskBB modules that are loaded for hooks to be registered. Consequentially, plugins must either be explicitly imported into the `flaskbb.app` namespace directly or into a namespace that is loaded there (directly or indirectly, e.g. how `flaskbb.users` is indirectly loaded)
2. `run_hook` now accepts an `is_markup` flag to determine if it should return a `Markup` or a raw `TemplateEventResult`.