### PR TITLE
Make default logging more flexible

### DIFF
--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -357,45 +357,21 @@ def configure_logging(app):
 
 
 def configure_default_logging(app):
-    logs_folder = app.config.get('LOG_PATH')
+    # TODO: Remove this once Flask 0.13 is released
+    app.config["LOGGER_NAME"] = "flask.app"
 
-    if logs_folder is None:
-        logs_folder = os.path.join(app.root_path, os.pardir, "logs")
-
-    default_log_format = '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-
-    formatter = logging.Formatter(
-        app.config.get('LOG_FORMAT') or default_log_format
-    )
-
-    info_log = os.path.join(logs_folder, app.config['INFO_LOG'])
-
-    info_file_handler = logging.handlers.RotatingFileHandler(
-        info_log, maxBytes=100000, backupCount=10
-    )
-
-    log_level = app.config.get('LOG_LEVEL') or logging.INFO
-
-    info_file_handler.setLevel(log_level)
-    info_file_handler.setFormatter(formatter)
-    app.logger.addHandler(info_file_handler)
-
-    error_log = os.path.join(logs_folder, app.config['ERROR_LOG'])
-
-    error_file_handler = logging.handlers.RotatingFileHandler(
-        error_log, maxBytes=100000, backupCount=10
-    )
-
-    error_file_handler.setLevel(logging.ERROR)
-    error_file_handler.setFormatter(formatter)
-    app.logger.addHandler(error_file_handler)
+    # Load default logging config
+    logging.config.dictConfig(app.config["LOG_DEFAULT_CONF"])
 
     if app.config["SEND_LOGS"]:
-        configure_mail_logs(app, formatter)
+        configure_mail_logs(app)
 
 
 def configure_mail_logs(app, formatter):
     from logging.handlers import SMTPHandler
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)-7s %(name)-25s %(message)s"
+    )
     mail_handler = SMTPHandler(
         app.config['MAIL_SERVER'], app.config['MAIL_DEFAULT_SENDER'],
         app.config['ADMINS'], 'application error, no admins specified',

--- a/flaskbb/configs/config.cfg.template
+++ b/flaskbb/configs/config.cfg.template
@@ -168,31 +168,85 @@ ADMINS = ["{{ mail_admin_address }}"]
 # If set to a file path, this should be an absolute file path
 LOG_CONF_FILE = {{ log_config_path or None }}
 
+# Path to store the INFO and ERROR logs
+# If None this defaults to flaskbb/logs
+#
+# If set to a file path, this should be an absolute path
+LOG_PATH = os.path.join(basedir, 'logs')
+
+# The default logging configuration that will be used when
+# USE_DEFAULT_LOGGING is set to True
+LOG_DEFAULT_CONF = {
+    'version': 1,
+    'disable_existing_loggers': False,
+
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s %(levelname)-7s %(name)-25s %(message)s'
+        },
+        'advanced': {
+            'format': '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
+        }
+    },
+
+    'handlers': {
+        'console': {
+            'level': 'NOTSET',
+            'formatter': 'standard',
+            'class': 'logging.StreamHandler',
+        },
+        'flaskbb': {
+            'level': 'DEBUG',
+            'formatter': 'standard',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_PATH, 'flaskbb.log'),
+            'mode': 'a',
+            'maxBytes': 10485760,  # 10MB
+            'backupCount': 5,
+        },
+
+        'infolog': {
+            'level': 'INFO',
+            'formatter': 'standard',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_PATH, 'info.log'),
+            'mode': 'a',
+            'maxBytes': 10485760,  # 10MB
+            'backupCount': 5,
+        },
+        'errorlog': {
+            'level': 'ERROR',
+            'formatter': 'standard',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_PATH, 'error.log'),
+            'mode': 'a',
+            'maxBytes': 10485760,  # 10MB
+            'backupCount': 5,
+        }
+    },
+
+    'loggers': {
+        'flask.app': {
+            'handlers': ['infolog', 'errorlog'],
+            'level': 'INFO',
+            'propagate': True
+        },
+        'flaskbb': {
+            'handlers': ['console', 'flaskbb'],
+            'level': 'WARNING',
+            'propagate': True
+        },
+    }
+}
+
 # When set to True this will enable the default
 # FlaskBB logging configuration which uses the settings
 # below to determine logging
 USE_DEFAULT_LOGGING = True
 
-# Log format FlaskBB will use
-LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-
-# Log level FlaskBB will use
-LOG_LEVEL = "INFO"
-
 # If SEND_LOGS is set to True, the admins (see the mail configuration) will
 # recieve the error logs per email.
 SEND_LOGS = False
-
-# Path to store the INFO and ERROR logs
-# If None this defaults to flaskbb/logs
-#
-# If set to a file path, this should be an absolute path
-LOG_PATH = None
-
-# The filename for the info and error logs. The logfiles are stored
-# at the path specified in LOG_PATH
-INFO_LOG = "info.log"
-ERROR_LOG = "error.log"
 
 
 # FlaskBB Settings

--- a/flaskbb/configs/default.py
+++ b/flaskbb/configs/default.py
@@ -62,32 +62,83 @@ class DefaultConfig(object):
     # If set to a file path, this should be an absolute file path
     LOG_CONF_FILE = None
 
+    # Path to store the INFO and ERROR logs
+    # If None this defaults to flaskbb/logs
+    #
+    # If set to a file path, this should be an absolute path
+    LOG_PATH = os.path.join(basedir, 'logs')
+
+    LOG_DEFAULT_CONF = {
+        'version': 1,
+        'disable_existing_loggers': False,
+
+        'formatters': {
+            'standard': {
+                'format': '%(asctime)s %(levelname)-7s %(name)-25s %(message)s'
+            },
+            'advanced': {
+                'format': '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
+            }
+        },
+
+        'handlers': {
+            'console': {
+                'level': 'NOTSET',
+                'formatter': 'standard',
+                'class': 'logging.StreamHandler',
+            },
+            'flaskbb': {
+                'level': 'DEBUG',
+                'formatter': 'standard',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'filename': os.path.join(LOG_PATH, 'flaskbb.log'),
+                'mode': 'a',
+                'maxBytes': 10485760,  # 10MB
+                'backupCount': 5,
+            },
+
+            'infolog': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'filename': os.path.join(LOG_PATH, 'info.log'),
+                'mode': 'a',
+                'maxBytes': 10485760,  # 10MB
+                'backupCount': 5,
+            },
+            'errorlog': {
+                'level': 'ERROR',
+                'formatter': 'standard',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'filename': os.path.join(LOG_PATH, 'error.log'),
+                'mode': 'a',
+                'maxBytes': 10485760,  # 10MB
+                'backupCount': 5,
+            }
+        },
+
+        'loggers': {
+            'flask.app': {
+                'handlers': ['infolog', 'errorlog'],
+                'level': 'INFO',
+                'propagate': True
+            },
+            'flaskbb': {
+                'handlers': ['console', 'flaskbb'],
+                'level': 'WARNING',
+                'propagate': True
+            },
+        }
+    }
+
     # When set to True this will enable the default
     # FlaskBB logging configuration which uses the settings
     # below to determine logging
     USE_DEFAULT_LOGGING = True
 
-    # Log format FlaskBB will use
-    LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-
-    # Log level FlaskBB will use
-    LOG_LEVEL = "INFO"
-
     # If SEND_LOGS is set to True, the admins (see the mail configuration) will
     # recieve the error logs per email.
     SEND_LOGS = False
-
-    # Path to store the INFO and ERROR logs
-    # If None this defaults to flaskbb/logs
-    #
-    # If set to a file path, this should be an absolute path
-    LOG_PATH = None
-
-    # The filename for the info and error logs. The logfiles are stored
-    # at the path specified in LOG_PATH
-    INFO_LOG = "info.log"
-    ERROR_LOG = "error.log"
-
 
     # Database
     # ------------------------------


### PR DESCRIPTION
Configuring the default loggers using a dictConfig instead of doing it programmatically seems to be a better idea imho. @justanr thoughts?