### PR TITLE
Mark 'flaskbb.*' plugins as internal plugins

### DIFF
--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -413,15 +413,14 @@ def load_plugins(app):
     # have to find all the flaskbb modules that are loaded this way
     # otherwise sys.modules might change while we're iterating it
     # because of imports and that makes Python very unhappy
-    # Converting it to a set is neccessary because we are not interested
-    # in duplicated plugins or invalid ones ('None' - appears on py2)
+    # we are not interested in duplicated plugins or invalid ones
+    # ('None' - appears on py2) and thus using a set
     flaskbb_modules = set(
         module for name, module in iteritems(sys.modules)
         if name.startswith('flaskbb')
     )
     for module in flaskbb_modules:
-        app.pluggy.register(module)
-        app.pluggy.mark_as_internal_plugin(module)
+        app.pluggy.register(module, internal=True)
 
     try:
         with app.app_context():

--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -419,6 +419,7 @@ def load_plugins(app):
     ]
     for module in flaskbb_modules:
         app.pluggy.register(module)
+        app.pluggy.mark_as_internal_plugin(module)
 
     try:
         with app.app_context():

--- a/flaskbb/app.py
+++ b/flaskbb/app.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 from flask import Flask, request
 from flask_login import current_user
 
-from flaskbb._compat import string_types
+from flaskbb._compat import string_types, iteritems
 # views
 from flaskbb.user.views import user
 from flaskbb.message.views import message
@@ -413,10 +413,12 @@ def load_plugins(app):
     # have to find all the flaskbb modules that are loaded this way
     # otherwise sys.modules might change while we're iterating it
     # because of imports and that makes Python very unhappy
-    flaskbb_modules = [
-        module for name, module in sys.modules.items()
+    # Converting it to a set is neccessary because we are not interested
+    # in duplicated plugins or invalid ones ('None' - appears on py2)
+    flaskbb_modules = set(
+        module for name, module in iteritems(sys.modules)
         if name.startswith('flaskbb')
-    ]
+    )
     for module in flaskbb_modules:
         app.pluggy.register(module)
         app.pluggy.mark_as_internal_plugin(module)

--- a/flaskbb/utils/translations.py
+++ b/flaskbb/utils/translations.py
@@ -41,6 +41,7 @@ class FlaskBBDomain(Domain):
         locale = get_locale()
         # now load and add the plugin translations
         for plugin in self.plugin_translations:
+            logger.debug("Loading plugin translation from: {}".format(plugin))
             plugin_translation = babel.support.Translations.load(
                 dirname=plugin,
                 locales=locale,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,4 @@ from tests.fixtures.forum import *  # noqa
 from tests.fixtures.user import *  # noqa
 from tests.fixtures.message import *  # noqa
 from tests.fixtures.settings_fixture import *  # noqa
+from tests.fixtures.plugin import *  # noqa

--- a/tests/fixtures/plugin.py
+++ b/tests/fixtures/plugin.py
@@ -1,0 +1,7 @@
+import pytest
+from flaskbb.plugins.manager import FlaskBBPluginManager
+
+
+@pytest.fixture
+def plugin_manager():
+    return FlaskBBPluginManager("flaskbb")

--- a/tests/unit/test_pluginmanager.py
+++ b/tests/unit/test_pluginmanager.py
@@ -1,0 +1,108 @@
+# some tests have been taking from
+# https://github.com/pytest-dev/pluggy/blob/master/testing/test_pluginmanager.py
+# and are licensed under the MIT License.
+import pytest
+
+
+def test_pluginmanager(plugin_manager):
+    """Tests basic pluggy plugin registration."""
+    class A(object):
+        pass
+
+    a1, a2 = A(), A()
+    plugin_manager.register(a1)
+    assert plugin_manager.is_registered(a1)
+    plugin_manager.register(a2, "hello")
+    assert plugin_manager.is_registered(a2)
+
+    with pytest.raises(ValueError):
+        assert plugin_manager.register(a1, internal=True)
+
+    out = plugin_manager.get_plugins()
+    assert a1 in out
+    assert a2 in out
+    assert plugin_manager.get_plugin('hello') == a2
+    assert plugin_manager.unregister(a1) == a1
+    assert not plugin_manager.is_registered(a1)
+
+    out = plugin_manager.list_name_plugin()
+    assert len(out) == 1
+    assert out == [("hello", a2)]
+    assert plugin_manager.list_name() == ["hello"]
+
+
+def test_register_internal(plugin_manager):
+    """Tests registration of internal flaskbb plugins."""
+    class A(object):
+        pass
+
+    a1, a2 = A(), A()
+    plugin_manager.register(a1, "notinternal")
+    plugin_manager.register(a2, "internal", internal=True)
+    assert plugin_manager.is_registered(a2)
+
+    out = plugin_manager.list_name_plugin()
+    assert ('notinternal', a1) in out
+    assert ('internal', a2) not in out
+
+    out_internal = plugin_manager.list_internal_name_plugin()
+    assert ('notinternal', a1) not in out_internal
+    assert ('internal', a2) in out_internal
+
+    assert plugin_manager.unregister(a2) == a2
+    assert not plugin_manager.list_internal_name_plugin()  # should be empty
+
+
+def test_set_blocked(plugin_manager):
+    class A(object):
+        pass
+
+    a1 = A()
+    name = plugin_manager.register(a1)
+    assert plugin_manager.is_registered(a1)
+    assert not plugin_manager.is_blocked(name)
+    plugin_manager.set_blocked(name)
+    assert plugin_manager.is_blocked(name)
+    assert not plugin_manager.is_registered(a1)
+
+    plugin_manager.set_blocked("somename")
+    assert plugin_manager.is_blocked("somename")
+    assert not plugin_manager.register(A(), "somename")
+    plugin_manager.unregister(name="somename")
+    assert plugin_manager.is_blocked("somename")
+
+
+def test_set_blocked_internal(plugin_manager):
+    class A(object):
+        pass
+
+    a1 = A()
+    name = plugin_manager.register(a1, internal=True)
+    assert plugin_manager.is_registered(a1)
+    assert not plugin_manager.is_blocked(name)
+    plugin_manager.set_blocked(name)
+    assert plugin_manager.is_blocked(name)
+    assert not plugin_manager.is_registered(a1)
+
+
+def test_get_internal_plugin(plugin_manager):
+    class A(object):
+        pass
+
+    a1, a2 = A(), A()
+    plugin_manager.register(a1, "notinternal")
+    plugin_manager.register(a2, "internal", internal=True)
+    assert plugin_manager.get_plugin('notinternal') == a1
+    assert plugin_manager.get_plugin('internal') == a2
+
+
+def test_get_internal_name(plugin_manager):
+    class A(object):
+        pass
+
+    a1, a2 = A(), A()
+    plugin_manager.register(a1, "notinternal")
+    plugin_manager.register(a2, "internal", internal=True)
+
+    assert plugin_manager.get_name(a1) == "notinternal"
+    assert plugin_manager.get_name(a2) == "internal"

--- a/tests/unit/utils/test_translations.py
+++ b/tests/unit/utils/test_translations.py
@@ -1,49 +1,14 @@
-import subprocess
-import os
 from flask import current_app
-from babel.support import Translations, NullTranslations
+from babel.support import Translations
 from flaskbb.utils.translations import FlaskBBDomain
-import pytest
 
 
-def _remove_compiled_translations():
-    translations_folder = os.path.join(current_app.root_path, "translations")
-
-    # walks through the translations folder and deletes all files
-    # ending with .mo
-    for root, dirs, files in os.walk(translations_folder):
-        for name in files:
-            if name.endswith(".mo"):
-                os.unlink(os.path.join(root, name))
-
-
-def _compile_translations():
-    PLUGINS_FOLDER = os.path.join(current_app.root_path, "plugins")
-    translations_folder = os.path.join(current_app.root_path, "translations")
-
-    subprocess.call(["pybabel", "compile", "-d", translations_folder])
-
-    for plugin in plugin_manager.all_plugins:
-        plugin_folder = os.path.join(PLUGINS_FOLDER, plugin)
-        translations_folder = os.path.join(plugin_folder, "translations")
-        subprocess.call(["pybabel", "compile", "-d", translations_folder])
-
-
-@pytest.mark.skip(reason="Plugin transition")
 def test_flaskbbdomain_translations(default_settings):
-    domain = FlaskBBDomain(current_app)
+    domain = current_app.extensions.get("babel").domain
 
     with current_app.test_request_context():
+        # no translations accessed and thus the cache is empty
         assert domain.get_translations_cache() == {}
-
-        # just to be on the safe side that there are really no compiled
-        # translations available
-        _remove_compiled_translations()
-        # no compiled translations are available
-        assert isinstance(domain.get_translations(), NullTranslations)
-
-        # lets compile them and test again
-        _compile_translations()
-
-        # now there should be translations :)
+        # load translations into cache
         assert isinstance(domain.get_translations(), Translations)
+        assert len(domain.get_translations_cache()) == 1  # 'en'


### PR DESCRIPTION
This would prevent to clutter the 'list_name', etc with all the flaskbb plugins (which are literally all flaskbb.* modules). Still needs some more work though.