### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
 # command to install dependencies
 install:
   - "pip install -r requirements-dev.txt"
@@ -13,6 +17,8 @@ install:
 # command to run tests
 script:
   - flaskbb translations compile
-  - py.test --cov=flaskbb --cov-report=term-missing tests
+  - py.test --cov=flaskbb --cov-report=term-missing --junit-xml=testresults.xml tests
+after_script:
+  - testspace [Python-${TRAVIS_PYTHON_VERSION}]testresults.xml{tests}
 after_success:
   - coveralls


### PR DESCRIPTION
Hi, `flasbb` team. We’ve made a few minor changes to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/).
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:flaskbb from our fork.

A few of the **benefits** for your Contributors:
 * Move beyond the flat, endless console output. Results in Testspace mirror your matrix jobs, test folders, suites, and cases hierarchy.
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

And for Owners:
 * Monitor the status of all your repositories, their local branches, and pull requests from a single dashboard.
 * View historical tracking of all your important metrics; test case and coverage growth, static analysis issues, custom metrics, etc.

[Read more...](https://blog.testspace.com/testspace-and-open-source/)

----

**Want to Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users
