### PR TITLE
Setup bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 2.0.0.dev0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+[bumpversion:file:flaskbb/__init__.py]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ Sphinx
 alabaster
 flake8
 tox==2.9.0
+bumpversion==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -64,14 +64,6 @@ def read(*parts):
         return fp.read()
 
 
-def find_version(*file_paths):
-    version_match = re.search(r'__version__\s+=\s+(.*)',
-                              read(*file_paths)).group(1)
-    if version_match:
-        return str(ast.literal_eval(version_match))
-    raise RuntimeError("Unable to find version string.")
-
-
 def get_requirements(e=None):
     rf = "requirements.txt" if e is None else 'requirements-{}.txt'.format(e)
     r = read(rf)
@@ -84,7 +76,7 @@ install_requires = get_requirements()
 
 setup(
     name='FlaskBB',
-    version=find_version("flaskbb", "__init__.py"),
+    version="2.0.0.dev0",
     url='https://github.com/sh4nks/flaskbb/',
     license='BSD',
     author='Peter Justin',


### PR DESCRIPTION
Sets up bumpversion for us. The 2.0.0 release needs to be run as `bumpversion --new-version "2.0.0"`